### PR TITLE
BugFix in GTFS-RT Service Alerts Processing

### DIFF
--- a/src/gtfsduckdb/adapter/gtfsrt.py
+++ b/src/gtfsduckdb/adapter/gtfsrt.py
@@ -78,7 +78,7 @@ class GtfsRealtimeAdapter:
                                 deleted_entity_selectors.append(i)
 
                         # finally, delete all invalid entity selectors
-                        for d in deleted_entity_selectors:
+                        for d in sorted(deleted_entity_selectors, reverse=True):
                             logger.warning(f"Removed entity selector [{d}] from service alert {matching_entity.id} as it contains no valid references")
                             del matching_entity.alert.informed_entity[d]
 


### PR DESCRIPTION
A bug in GTFS-RT service alerts processing has been fixed. This bug was occured everytime when alert entities are deleted during processing.