### PR TITLE
BugFix: Processing GTFS-RT Service Alerts

### DIFF
--- a/src/gtfsduckdb/adapter/gtfsrt.py
+++ b/src/gtfsduckdb/adapter/gtfsrt.py
@@ -80,6 +80,7 @@ class GtfsRealtimeAdapter:
                         # finally, delete all invalid entity selectors
                         for d in sorted(deleted_entity_selectors, reverse=True):
                             logger.warning(f"Removed entity selector [{d}] from service alert {matching_entity.id} as it contains no valid references")
+                            logger.debug(f"Entity selector index {d}, size is {len(matching_entity.alert.informed_entity)}")
                             del matching_entity.alert.informed_entity[d]
 
                         # if there's no entity selector left, skip this alert

--- a/src/gtfsduckdb/adapter/gtfsrt.py
+++ b/src/gtfsduckdb/adapter/gtfsrt.py
@@ -80,7 +80,6 @@ class GtfsRealtimeAdapter:
                         # finally, delete all invalid entity selectors
                         for d in sorted(deleted_entity_selectors, reverse=True):
                             logger.warning(f"Removed entity selector [{d}] from service alert {matching_entity.id} as it contains no valid references")
-                            logger.info(f"Entity selector index {d}, size is {len(matching_entity.alert.informed_entity)}")
                             del matching_entity.alert.informed_entity[d]
 
                         # if there's no entity selector left, skip this alert

--- a/src/gtfsduckdb/adapter/gtfsrt.py
+++ b/src/gtfsduckdb/adapter/gtfsrt.py
@@ -74,7 +74,7 @@ class GtfsRealtimeAdapter:
                             # TODO: what about the other fields of an entity selector ... ?
 
                             # mark entity selector as deleted, it contains no valid reference
-                            if not matching_entity.alert.informed_entity[i].HasField('route_id') and not matching_entity.alert.informed_entity[i].HasField('route_id'):
+                            if not matching_entity.alert.informed_entity[i].HasField('route_id') and not matching_entity.alert.informed_entity[i].HasField('stop_id'):
                                 deleted_entity_selectors.append(i)
 
                         # finally, delete all invalid entity selectors

--- a/src/gtfsduckdb/adapter/gtfsrt.py
+++ b/src/gtfsduckdb/adapter/gtfsrt.py
@@ -80,7 +80,7 @@ class GtfsRealtimeAdapter:
                         # finally, delete all invalid entity selectors
                         for d in sorted(deleted_entity_selectors, reverse=True):
                             logger.warning(f"Removed entity selector [{d}] from service alert {matching_entity.id} as it contains no valid references")
-                            logger.debug(f"Entity selector index {d}, size is {len(matching_entity.alert.informed_entity)}")
+                            logger.info(f"Entity selector index {d}, size is {len(matching_entity.alert.informed_entity)}")
                             del matching_entity.alert.informed_entity[d]
 
                         # if there's no entity selector left, skip this alert


### PR DESCRIPTION
GTFS-RT service alerts are now processed correctly again even with invalid entity selectors. Invalid entity selectors are removed from the database.