### PR TITLE
Wildcards for Route and Stop Mapping

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug: Realtime",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "gtfsduckdb",
+            "python": "${workspaceFolder}/venv/Scripts/python.exe",
+            "env": {"PYTHONPATH": "${workspaceRoot}/src"},
+            "args": [
+                "realtime",
+                "./sampledata/gtfs.ddb",
+                "-p", "8030",
+                "-h", "127.0.0.1",
+                "-c", "./sampledata/gtfsduckdb-realtime.yaml"
+            ]
+        }
+    ]
+}

--- a/src/gtfsduckdb/__main__.py
+++ b/src/gtfsduckdb/__main__.py
@@ -30,8 +30,8 @@ def version():
 @click.option('--input', '-i', help='Directory or ZIP file containing GTFS data')
 def load(database, input):
 
-    lake = GtfsDuckDB(database)
-    lake.load_static(input)
+    ddb = GtfsDuckDB(database)
+    ddb.load_static(input)
 
 @cli.command()
 @click.argument('database')
@@ -40,18 +40,18 @@ def load(database, input):
 @click.option('--trips', '-t', multiple=True, help='Pattern matching the trip IDs to be removed')
 def remove(database, agencies, routes, trips):
 
-    lake = GtfsDuckDB(database)
+    ddb = GtfsDuckDB(database)
 
     for agency in agencies:
-        lake.remove_agencies(agency, False)
+        ddb.remove_agencies(agency, False)
     
     for route in routes:
-        lake.remove_routes(route, False)
+        ddb.remove_routes(route, False)
 
     for trip in trips:
-        lake.remove_trips(trip, False)
+        ddb.remove_trips(trip, False)
 
-    lake._remove_dependent_objects()
+    ddb._remove_dependent_objects()
 
 @cli.command()
 @click.argument('database')
@@ -59,28 +59,28 @@ def remove(database, agencies, routes, trips):
 @click.option('--strategy', '-s', default='match_stop_id', help='Strategy used for matching existing data between the actual database and the subset')
 def drop(database, inputs, strategy):
     
-    lake = GtfsDuckDB(database)
+    ddb = GtfsDuckDB(database)
 
     for subset in inputs:
-        lake.drop_subset(subset, strategy_name=strategy)
+        ddb.drop_subset(subset, strategy_name=strategy)
 
 @cli.command()
 @click.argument('database')
 @click.option('--output', '-o', help='Destination directory or ZIP file containing GTFS data')
 def export(database, output):
     
-    lake = GtfsDuckDB(database)
-    lake.export_static(output)
+    ddb = GtfsDuckDB(database)
+    ddb.export_static(output)
 
 @cli.command()
 @click.argument('database')
 @click.option('--files', '-f', multiple=True, help='Filename of the file containing SQL statements')
 def sql(database, files):
 
-    lake = GtfsDuckDB(database)
+    ddb = GtfsDuckDB(database)
 
     for sql_file in files:
-        lake.execute_sql(sql_file)
+        ddb.execute_sql(sql_file)
 
 @cli.command()
 @click.argument('database')
@@ -92,10 +92,10 @@ def show(database, date, num_results, full_trips, output):
 
     ref = dt.datetime.strptime(date, '%Y%m%d')
     
-    lake = GtfsDuckDB(database)
+    ddb = GtfsDuckDB(database)
 
     start_time = time.time()
-    trips = lake.fetch_nominal_operation_day_trips(ref, full_trips)
+    trips = ddb.fetch_nominal_operation_day_trips(ref, full_trips)
     end_time = time.time()
 
     if output is not None:

--- a/src/gtfsduckdb/adapter/gtfsrt.py
+++ b/src/gtfsduckdb/adapter/gtfsrt.py
@@ -9,8 +9,8 @@ from ..mapping import map_id
 
 class GtfsRealtimeAdapter:
 
-    def __init__(self, config, lake, mappings):
-        self._lake = lake
+    def __init__(self, config, ddb, mappings):
+        self._ddb = ddb
         self._config = config
         self._mappings = mappings
 
@@ -106,11 +106,11 @@ class GtfsRealtimeAdapter:
 
     def _insert_service_alert(self, entity):
         service_alert, alert_active_periods, alert_informed_enities = self._transform_service_alert(entity)
-        self._lake.insert_realtime_service_alert(service_alert, alert_active_periods, alert_informed_enities)
+        self._ddb.insert_realtime_service_alert(service_alert, alert_active_periods, alert_informed_enities)
 
     def _delete_service_alert(self, entity):
         service_alert, alert_active_periods, alert_informed_enities = self._transform_service_alert(entity)
-        self._lake.delete_realtime_service_alert(service_alert, alert_active_periods, alert_informed_enities)
+        self._ddb.delete_realtime_service_alert(service_alert, alert_active_periods, alert_informed_enities)
 
     def _transform_service_alert(self, entity):
         service_alert_data = dict()
@@ -279,11 +279,11 @@ class GtfsRealtimeAdapter:
 
     def _insert_trip_update(self, entity):
         trip_update_data, trip_stop_time_update_data = self._transform_trip_update(entity)
-        self._lake.insert_realtime_trip_updates(trip_update_data, trip_stop_time_update_data)
+        self._ddb.insert_realtime_trip_updates(trip_update_data, trip_stop_time_update_data)
 
     def _delete_trip_update(self, entity):
         trip_update_data, trip_stop_time_update_data = self._transform_trip_update(entity)
-        self._lake.delete_realtime_trip_updates(trip_update_data, trip_stop_time_update_data)
+        self._ddb.delete_realtime_trip_updates(trip_update_data, trip_stop_time_update_data)
 
     def _transform_trip_update(self, entity):
         trip_update_data = dict()

--- a/src/gtfsduckdb/adapter/gtfsrt.py
+++ b/src/gtfsduckdb/adapter/gtfsrt.py
@@ -1,8 +1,11 @@
 import logging
+import re
 import time
 
 from google.transit import gtfs_realtime_pb2
 from google.protobuf.message import DecodeError
+
+from ..mapping import map_id
 
 class GtfsRealtimeAdapter:
 
@@ -56,8 +59,8 @@ class GtfsRealtimeAdapter:
                             # map and verify route_id
                             if matching_entity.alert.informed_entity[i].HasField('route_id'):
                                 route_id = matching_entity.alert.informed_entity[i].route_id
-                                if 'routes' in self._mappings and route_id in self._mappings['routes']:
-                                    matching_entity.alert.informed_entity[i].route_id = self._mappings['routes'][route_id]
+                                if 'routes' in self._mappings:
+                                    matching_entity.alert.informed_entity[i].route_id = map_id(route_id, self._mappings['routes'])
 
                                 if matching_entity.alert.informed_entity[i].route_id not in self._nominal_route_ids:
                                     matching_entity.alert.informed_entity[i].ClearField('route_id')
@@ -65,8 +68,8 @@ class GtfsRealtimeAdapter:
                             # map and verify stop_id
                             if matching_entity.alert.informed_entity[i].HasField('stop_id'):
                                 stop_id = matching_entity.alert.informed_entity[i].stop_id
-                                if 'stops' in self._mappings and stop_id in self._mappings['stops']:
-                                    matching_entity.alert.informed_entity[i].stop_id = self._mappings['stops'][stop_id]
+                                if 'stops' in self._mappings:
+                                    matching_entity.alert.informed_entity[i].stop_id = map_id(stop_id, self._mappings['stops'])
                     
                                 if matching_entity.alert.informed_entity[i].stop_id not in self._nominal_stop_ids:
                                     matching_entity.alert.informed_entity[i].ClearField('stop_id')
@@ -176,13 +179,13 @@ class GtfsRealtimeAdapter:
 
                     # map route and stop IDs
                     route_id = matching_entity.trip_update.trip.route_id if matching_entity.trip_update.HasField('trip') and matching_entity.trip_update.trip.HasField('route_id') else None
-                    if 'routes' in self._mappings and route_id in self._mappings['routes']:
-                        matching_entity.trip_update.trip.route_id = self._mappings['routes'][route_id]
+                    if 'routes' in self._mappings:
+                        matching_entity.trip_update.trip.route_id = map_id(route_id, self._mappings['routes'])
 
                     for stop_time_update in matching_entity.trip_update.stop_time_update:
                         stop_id = stop_time_update.stop_id if stop_time_update.HasField('stop_id') else None
                         if 'stops' in self._mappings and stop_id in self._mappings['stops']:
-                            stop_time_update.stop_id = self._mappings['stops'][stop_id]
+                            stop_time_update.stop_id = map_id(stop_id, self._mappings['stops'])
 
                     # check whether the trip is already known or must be matched
                     if matching_entity.trip_update.trip.trip_id in self._nominal_trips_ids: # if the trip ID is already known from nominal trip IDs

--- a/src/gtfsduckdb/adapter/gtfsrt.py
+++ b/src/gtfsduckdb/adapter/gtfsrt.py
@@ -60,6 +60,8 @@ class GtfsRealtimeAdapter:
                             if matching_entity.alert.informed_entity[i].HasField('route_id'):
                                 route_id = matching_entity.alert.informed_entity[i].route_id
                                 if 'routes' in self._mappings:
+                                    logging.info('Mapping route ID now ...')
+                                    logging.info(f"{route_id} ---> {map_id(route_id, self._mappings['routes'])}")
                                     matching_entity.alert.informed_entity[i].route_id = map_id(route_id, self._mappings['routes'])
                                 else:
                                     logging.warning(f'No mapping for {matching_entity.id}')

--- a/src/gtfsduckdb/adapter/gtfsrt.py
+++ b/src/gtfsduckdb/adapter/gtfsrt.py
@@ -61,9 +61,13 @@ class GtfsRealtimeAdapter:
                                 route_id = matching_entity.alert.informed_entity[i].route_id
                                 if 'routes' in self._mappings:
                                     matching_entity.alert.informed_entity[i].route_id = map_id(route_id, self._mappings['routes'])
+                                else:
+                                    logging.warning(f'No mapping for {matching_entity.id}')
 
                                 if matching_entity.alert.informed_entity[i].route_id not in self._nominal_route_ids:
                                     matching_entity.alert.informed_entity[i].ClearField('route_id')
+                            else:
+                                logging.warning(f'No route_id in {matching_entity.id}')
 
                             # map and verify stop_id
                             if matching_entity.alert.informed_entity[i].HasField('stop_id'):

--- a/src/gtfsduckdb/adapter/gtfsrt.py
+++ b/src/gtfsduckdb/adapter/gtfsrt.py
@@ -60,16 +60,16 @@ class GtfsRealtimeAdapter:
                             if matching_entity.alert.informed_entity[i].HasField('route_id'):
                                 route_id = matching_entity.alert.informed_entity[i].route_id
                                 if 'routes' in self._mappings:
-                                    logging.info('Mapping route ID now ...')
-                                    logging.info(f"{route_id} ---> {map_id(route_id, self._mappings['routes'])}")
+                                    logger.info('Mapping route ID now ...')
+                                    logger.info(f"{route_id} ---> {map_id(route_id, self._mappings['routes'])}")
                                     matching_entity.alert.informed_entity[i].route_id = map_id(route_id, self._mappings['routes'])
                                 else:
-                                    logging.warning(f'No mapping for {matching_entity.id}')
+                                    logger.warning(f'No mapping for {matching_entity.id}')
 
                                 if matching_entity.alert.informed_entity[i].route_id not in self._nominal_route_ids:
                                     matching_entity.alert.informed_entity[i].ClearField('route_id')
                             else:
-                                logging.warning(f'No route_id in {matching_entity.id}')
+                                logger.warning(f'No route_id in {matching_entity.id}')
 
                             # map and verify stop_id
                             if matching_entity.alert.informed_entity[i].HasField('stop_id'):

--- a/src/gtfsduckdb/adapter/gtfsrt.py
+++ b/src/gtfsduckdb/adapter/gtfsrt.py
@@ -60,16 +60,10 @@ class GtfsRealtimeAdapter:
                             if matching_entity.alert.informed_entity[i].HasField('route_id'):
                                 route_id = matching_entity.alert.informed_entity[i].route_id
                                 if 'routes' in self._mappings:
-                                    logger.info('Mapping route ID now ...')
-                                    logger.info(f"{route_id} ---> {map_id(route_id, self._mappings['routes'])}")
                                     matching_entity.alert.informed_entity[i].route_id = map_id(route_id, self._mappings['routes'])
-                                else:
-                                    logger.warning(f'No mapping for {matching_entity.id}')
 
                                 if matching_entity.alert.informed_entity[i].route_id not in self._nominal_route_ids:
                                     matching_entity.alert.informed_entity[i].ClearField('route_id')
-                            else:
-                                logger.warning(f'No route_id in {matching_entity.id}')
 
                             # map and verify stop_id
                             if matching_entity.alert.informed_entity[i].HasField('stop_id'):

--- a/src/gtfsduckdb/mapping.py
+++ b/src/gtfsduckdb/mapping.py
@@ -1,0 +1,10 @@
+import re
+
+def map_id(id:str, mapping:dict) -> str|None:
+
+    rgx: str = id.replace('*', '.*')
+    for key, value in mapping.items():
+        if re.match(rgx, key):
+            return value
+        
+    return None

--- a/src/gtfsduckdb/mapping.py
+++ b/src/gtfsduckdb/mapping.py
@@ -2,9 +2,9 @@ import re
 
 def map_id(id:str, mapping:dict) -> str|None:
 
-    rgx: str = id.replace('*', '.*')
     for key, value in mapping.items():
-        if re.match(rgx, key):
+        rgx: str = key.replace('*', '.*')
+        if re.match(rgx, id):
             return value
         
     return None

--- a/src/gtfsduckdb/mapping.py
+++ b/src/gtfsduckdb/mapping.py
@@ -5,6 +5,7 @@ def map_id(id:str, mapping:dict) -> str|None:
 
     for key, value in mapping.items():
         if re.match(key, id):
+            logging.info(f"{key} does match {value}")
             return value
         else:
             logging.warning(f"{key} does not match {value}")

--- a/src/gtfsduckdb/mapping.py
+++ b/src/gtfsduckdb/mapping.py
@@ -3,8 +3,7 @@ import re
 def map_id(id:str, mapping:dict) -> str|None:
 
     for key, value in mapping.items():
-        rgx: str = key.replace('*', '.*')
-        if re.match(rgx, id):
+        if re.match(key, id):
             return value
         
-    return None
+    return id

--- a/src/gtfsduckdb/mapping.py
+++ b/src/gtfsduckdb/mapping.py
@@ -1,9 +1,12 @@
 import re
+import logging
 
 def map_id(id:str, mapping:dict) -> str|None:
 
     for key, value in mapping.items():
         if re.match(key, id):
             return value
+        else:
+            logging.warning(f"{key} does not match {value}")
         
     return id

--- a/src/gtfsduckdb/mapping.py
+++ b/src/gtfsduckdb/mapping.py
@@ -3,6 +3,8 @@ import logging
 
 def map_id(id:str, mapping:dict) -> str|None:
 
+    logging.info(mapping)
+    
     for key, value in mapping.items():
         if re.match(key, id):
             logging.info(f"{key} does match {value}")

--- a/src/gtfsduckdb/mapping.py
+++ b/src/gtfsduckdb/mapping.py
@@ -1,15 +1,9 @@
 import re
-import logging
 
 def map_id(id:str, mapping:dict) -> str|None:
 
-    logging.info(mapping)
-    
     for key, value in mapping.items():
         if re.match(key, id):
-            logging.info(f"{key} does match {value}")
             return value
-        else:
-            logging.warning(f"{key} does not match {value}")
         
     return id

--- a/src/gtfsduckdb/realtime.py
+++ b/src/gtfsduckdb/realtime.py
@@ -268,7 +268,7 @@ class GtfsRealtimeServer:
     async def _service_alerts(self, request: Request) -> Response:
 
         # check whether there're cached data
-        format = request.query_params['f'] if 'f' in request.query_params else 'pbf'
+        format = 'json' if 'debug' in request.query_params else 'pbf'
         if self._cache is not None:
             cached_response = self._cache.get(f"{request.url.path}-{format}")
             if cached_response is not None:
@@ -383,7 +383,7 @@ class GtfsRealtimeServer:
     async def _trip_updates(self, request: Request) -> Response:
 
         # check whether there're cached data
-        format = request.query_params['f'] if 'f' in request.query_params else 'pbf'
+        format = 'json' if 'debug' in request.query_params else 'pbf'
         if self._cache is not None:
             cached_response = self._cache.get(f"{request.url.path}-{format}")
             if cached_response is not None:
@@ -479,7 +479,7 @@ class GtfsRealtimeServer:
     async def _vehicle_positions(self, request: Request) -> Response:
 
         # check whether there're cached data
-        format = request.query_params['f'] if 'f' in request.query_params else 'pbf'
+        format = 'json' if 'debug' in request.query_params else 'pbf'
         if self._cache is not None:
             cached_response = self._cache.get(f"{request.url.path}-{format}")
             if cached_response is not None:


### PR DESCRIPTION
When using mapping tables to modify route and stop IDs before processing in realtime, wildcards and regular expressions can be used from now on. Instead of hard-writing every possible value for a certain route ID, you can now write `your:route:id*` which matches every incoming route ID with `your:route:id` at the beginning and every possible char afterwards. The same works for stop IDs.

Additionally, the `f` query param for JSON output of the realtime server is migrated to `debug`. Simply adding the the query param `debug` without a value leads the server to output a JSON dump instead of protobuf.