### PR TITLE
Publish GTFS-RT ServiceAlerts as RSS-Feed

### DIFF
--- a/gtfsduckdb-realtime.yaml
+++ b/gtfsduckdb-realtime.yaml
@@ -42,3 +42,5 @@ rss:
   title: Demo Public Transport Alerts
   description: All public transport alerts in realtime as RSS feed.
   language: de-DE
+  base_url: https://yourdomain.dev
+  media_url: https://www.vpe.de/wp-content/uploads/2023/11/baustelle.jpeg

--- a/gtfsduckdb-realtime.yaml
+++ b/gtfsduckdb-realtime.yaml
@@ -43,4 +43,4 @@ rss:
   description: All public transport alerts in realtime as RSS feed.
   language: de-DE
   base_url: https://yourdomain.dev
-  media_url: https://www.vpe.de/wp-content/uploads/2023/11/baustelle.jpeg
+  media_url: https://yourdomain.dev/image.jpg

--- a/gtfsduckdb-realtime.yaml
+++ b/gtfsduckdb-realtime.yaml
@@ -3,10 +3,12 @@ app:
   monitor_enabled: true
   cors_enabled: true
   mqtt_enabled: true
+  rss_enabled: false
   routing:
     service_alerts_endpoint: /gtfs/realtime/service-alerts.pbf
     trip_updates_endpoint: /gtfs/realtime/trip-updates.pbf
     vehicle_positions_endpoint: /gtfs/realtime/vehicle-positions.pbf
+    rss_endpoint: /gtfs/realtime/rss.xml
     monitor_endpoint: /monitor
   data_review_seconds: 7200
   timezone: 'Europe/Berlin'
@@ -36,3 +38,7 @@ mqtt:
       type: gtfsrt-trip-updates
     - topic: realtime/sample/vehiclepositions/#
       type: gtfsrt-vehicle-positions
+rss:
+  title: Demo Public Transport Alerts
+  description: All public transport alerts in realtime as RSS feed.
+  language: de-DE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "duckdb",
     "fastapi",
     "gtfs-realtime-bindings",
+    "lxml",
     "paho-mqtt",
     "polars",
     "protobuf",

--- a/src/gtfsduckdb/config.py
+++ b/src/gtfsduckdb/config.py
@@ -11,10 +11,12 @@ class Configuration:
                 'monitor_enabled': True,
                 'cors_enabled': True,
                 'mqtt_enabled': True,
+                'rss_enabled': False,
                 'routing': {
                     'service_alerts_endpoint': '/gtfs/realtime/service-alerts.pbf',
                     'trip_updates_endpoint': '/gtfs/realtime/trip-updates.pbf',
                     'vehicle_positions_endpoint': '/gtfs/realtime/vehicle-positions.pbf',
+                    'rss_endpoint': '/gtfs/realtime/rss.xml',
                     'monitor_endpoint': '/monitor'
                 },
                 'data_review_seconds': 7200,
@@ -39,6 +41,11 @@ class Configuration:
                 'username': None,
                 'password': None,
                 'subscriptions': []
+            },
+            'rss': {
+                'title': 'Demo Public Transport Alerts',
+                'description': 'All public transport alerts in realtime as RSS feed.',
+                'language': 'de-DE'
             }
         }
 

--- a/src/gtfsduckdb/config.py
+++ b/src/gtfsduckdb/config.py
@@ -45,7 +45,9 @@ class Configuration:
             'rss': {
                 'title': 'Demo Public Transport Alerts',
                 'description': 'All public transport alerts in realtime as RSS feed.',
-                'language': 'de-DE'
+                'language': 'de-DE',
+                'base_url': 'https://yourdomain.dev',
+                'media_url': 'https://yourdomain.dev/media/default.jpg'
             }
         }
 

--- a/src/gtfsduckdb/dict2xml.py
+++ b/src/gtfsduckdb/dict2xml.py
@@ -1,0 +1,71 @@
+from lxml import etree
+from lxml.etree import CDATA
+
+_CONST_ATTRIB_INDICATOR = '#'
+
+def _build_xml_element(parent, d, wrap_lists):    
+    if isinstance(d, dict):
+        attrib = {}
+        content = {}
+
+        for key, value in d.items():
+            if key == '$name' or key == '$text':
+                pass
+            elif key.startswith(_CONST_ATTRIB_INDICATOR):
+                attrib[key.replace(_CONST_ATTRIB_INDICATOR, '')] = str(value)
+            else:
+                content[key.replace(_CONST_ATTRIB_INDICATOR, '')] = value
+
+        parent.attrib.update(attrib)
+
+        if parent.text is None:
+            for key, value in content.items():
+                if isinstance(value, list):
+                    if wrap_lists:
+                        wrap = etree.SubElement(parent, key)
+                        for item in value:
+                            if not '$name' in item:
+                                raise RuntimeError('wrapped list element does not contain required key $name')
+                            
+                            child = etree.SubElement(wrap, item['$name'])
+                            _build_xml_element(child, item, wrap_lists)
+                    else:
+                        for item in value:
+                            child = etree.SubElement(parent, key)
+                            _build_xml_element(child, item, wrap_lists)
+                else:
+                    if isinstance(value, dict) and '$name' in value:
+                        name = value['$name']
+                    else: 
+                        name = key
+
+                    child = etree.SubElement(parent, name)
+
+                    if isinstance(value, dict) and '$text' in value:
+                        child.text = value['$text']
+                        _build_xml_element(child, value, wrap_lists)
+                    else:
+                        _build_xml_element(child, value, wrap_lists)
+    else:
+        d = str(d)
+        if d.startswith('<![CDATA['):
+            d = d.replace('<![CDATA[', '').replace(']]>', '')
+            parent.text = CDATA(d)
+        else:
+            parent.text = str(d)
+
+def dict2xml(root, d, pretty_print=True, xml_declaration=True, wrap_lists=False) -> str:
+    root = etree.Element(root)
+    _build_xml_element(root, d, wrap_lists)
+
+    if pretty_print:
+        etree.indent(root, space="    ")
+
+    xml_str: str = etree.tostring(
+        root, 
+        pretty_print=pretty_print, 
+        xml_declaration=xml_declaration, 
+        encoding='UTF-8'
+    )
+
+    return xml_str

--- a/src/gtfsduckdb/dict2xml.py
+++ b/src/gtfsduckdb/dict2xml.py
@@ -38,7 +38,7 @@ def _build_xml_element(parent, d, wrap_lists, nsmap):
                             _build_xml_element(child, item, wrap_lists, nsmap)
                     else:
                         for item in value:
-                            name = item['$name']
+                            name = item['$name'] if '$name' in item else key
 
                             if '$ns' in item and item['$ns'] in nsmap:
                                 ns_url: str = nsmap[item['$ns']]

--- a/src/gtfsduckdb/realtime.py
+++ b/src/gtfsduckdb/realtime.py
@@ -643,11 +643,16 @@ class GtfsRealtimeServer:
 
         rss = {
             '#version': '2.0',
-            #'#xmlns:atom': 'http://www.w3.org/2005/Atom',
             'channel': {
                 'title': self._config['rss']['title'],
                 'description': self._config['rss']['description'],
                 'language': self._config['rss']['language'],
+                'link': {
+                    '$ns': 'atom',
+                    '#href': f"{self._config['rss']['base_url']}{self._config['app']['routing']['rss_endpoint']}",
+                    '#rel': 'self',
+                    '#type': 'application/rss+xml'
+                },
                 'item': list()
             }
         }
@@ -674,13 +679,24 @@ class GtfsRealtimeServer:
                 'link': link,
                 'guid': guid,
                 'pubDate': pub_date,
-                'description': f"<![CDATA[{description}]]>"
+                'description': f"<![CDATA[{description}]]>",
+                'content': {
+                    '$ns': 'media',
+                    '#url': f"{self._config['rss']['media_url']}",
+                    '#medium': 'image'
+                }
             })
+
+        namespaces: dict = {
+            'atom': 'http://www.w3.org/2005/Atom',
+            'media': 'http://search.yahoo.com/mrss/'
+        }
 
         return Response(content=dict2xml(
             'rss',
             rss,
-            pretty_print=True
+            pretty_print=True,
+            nsmap=namespaces
         ), media_type='application/rss+xml')
 
 


### PR DESCRIPTION
The realtime server implementation has been extended with a simple endpoint for a RSS feed with all service alerts. 

Configuration needs to be enhanced as follows for the RSS feed to work:

```yaml
app:
  rss_enabled: true
...
rss:
  title: Demo Public Transport Alerts
  description: All public transport alerts in realtime as RSS feed.
  language: de-DE
  base_url: https://yourdomain.dev
  media_url: https://yourdomain.dev/image.jpg
```